### PR TITLE
Fixes: `.pyi` not included issue that comes with `v2.0.0`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include pyfilehandling/py.typed
+include pyfilehandling/*.pyi
+include pyfilehandling/files/*.pyi

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     },
     license='MIT',
     package_data={
-        'your_package': ['*.pyi'],
+        'pyfilehandling': ['*.pyi'],
     },
     python_requires='>=3.9',
 )

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,5 @@ setup(
         'Source Code': 'https://github.com/JeelDobariya38/PyFileHandling',
     },
     license='MIT',
-    package_data={
-        'pyfilehandling': ['*.pyi'],
-    },
     python_requires='>=3.9',
 )

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ long_description = read_file('README.md')
 
 setup(
     name='pyfilehandling',
-    version='2.0.0',
+    version='2.0.1',
     description='A Python package for file manipulation operations.',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Title: Fixes: `.pyi` not included issue that comes with `v2.0.0`

**Description:**

This pull request aims to fix a bug that has arise with `v2.0.0` release of not including `.pyi` in package

**Changes Proposed:**

- change `setup.py` to fixes this bug
- also add `MANIFEST.in` file to stay update with python community best practices

**Related Issue:**

- tries to fixes #13 


Please review this pull request and provide feedback, suggestions, or any necessary improvements. Let's collaborate to enhance PyFileHandling and ensure the quality and reliability of the codebase
