### PR TITLE
[Enhancement] Extend Release Workflow to Include Prereleases

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,7 +2,7 @@ name: Publish Package
 
 on:
   release:
-    types: [created]
+    types: [created, prereleased]
 
 jobs:
   test:


### PR DESCRIPTION
**Title: Extend Release Workflow to Include Prereleases**

**Description:**

This pull request aims to extend the release workflow to include prereleases. Currently, the workflow triggers only when a regular release is created, and it doesn't respond to prereleases. Prereleases play a vital role in our release management process as they allow us to test and ensure the software's stability before the final release.

**Changes Proposed:**

- Modified the release workflow configuration to include the `prereleased` event type.
- With this change, the workflow now triggers not only for regular releases but also for prereleases.

**Related Issue:**

- Fixes #19 (Support Prereleases in Release Workflow)

**Proposed Solution:**

- The solution involves updating the workflow configuration to handle prereleases effectively, ensuring that they are part of our release management process.

**Testing:**

- The modified workflow has been tested to ensure it triggers correctly for prereleases and regular releases.
- Additionally, the workflow has been tested with various Python versions (3.9, 3.10, 3.11, 3.12) to ensure compatibility.

**Documentation:**

- No documentation changes are required for this pull request.

**Additional Notes:**

- Including support for prereleases in our release workflow enhances our release management process and ensures that important actions are taken for all release types.

Please review this pull request, and let's collaborate to enhance our release process and make it more inclusive.